### PR TITLE
implement reactive CRUD for school terms #16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 .mvn/wrapper/maven-wrapper.jar
 !**/src/main/**/target/
 !**/src/test/**/target/
+aplication.properties
 
 ### STS ###
 .apt_generated

--- a/services/backend-api/src/main/java/ao/creativemode/kixi/controller/TermController.java
+++ b/services/backend-api/src/main/java/ao/creativemode/kixi/controller/TermController.java
@@ -1,0 +1,62 @@
+package ao.creativemode.kixi.controller;
+
+import ao.creativemode.kixi.dto.term.TermRequest;
+import ao.creativemode.kixi.dto.term.TermResponse;
+import ao.creativemode.kixi.service.TermService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+import java.util.List;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
+@RestController
+@RequestMapping("/api/v1/terms")
+public class TermController {
+
+    private final TermService service;
+
+    public TermController(TermService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public Mono<ResponseEntity<List<TermResponse>>> listAllActive() {
+        return service.findAllActive().collectList().map(ResponseEntity::ok);
+    }
+
+    @GetMapping("/trash")
+    public Mono<ResponseEntity<List<TermResponse>>> listTrashed() {
+        return service.findAllDeleted().collectList().map(ResponseEntity::ok);
+    }
+
+    @GetMapping("/{id}")
+    public Mono<ResponseEntity<TermResponse>> getById(@PathVariable Long id) {
+        return service.findByIdActive(id).map(ResponseEntity::ok);
+    }
+
+    @PostMapping
+    public Mono<ResponseEntity<TermResponse>> create(@Valid @RequestBody TermRequest request) {
+        return service.create(request).map(ResponseEntity::ok);
+    }
+
+    @PutMapping("/{id}")
+    public Mono<ResponseEntity<TermResponse>> update(@PathVariable Long id, @Valid @RequestBody TermRequest request) {
+        return service.update(id, request).map(ResponseEntity::ok);
+    }
+
+    @DeleteMapping("/{id}")
+    public Mono<ResponseEntity<Void>> softDelete(@PathVariable Long id) {
+        return service.softDelete(id).thenReturn(ResponseEntity.status(NO_CONTENT).build());
+    }
+
+    @PostMapping("/{id}/restore")
+    public Mono<ResponseEntity<Void>> restore(@PathVariable Long id) {
+        return service.restore(id).thenReturn(ResponseEntity.ok().build());
+    }
+
+    @DeleteMapping("/{id}/purge")
+    public Mono<ResponseEntity<Void>> hardDelete(@PathVariable Long id) {
+        return service.hardDelete(id).thenReturn(ResponseEntity.status(NO_CONTENT).build());
+    }
+}

--- a/services/backend-api/src/main/java/ao/creativemode/kixi/dto/term/TermRequest.java
+++ b/services/backend-api/src/main/java/ao/creativemode/kixi/dto/term/TermRequest.java
@@ -1,0 +1,14 @@
+package ao.creativemode.kixi.dto.term;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+public record TermRequest(
+        @NotBlank(message = "Name is required")
+        String name,
+
+        @NotNull(message = "Number is required")
+        @Positive(message = "Number must be positive")
+        int number
+) {}

--- a/services/backend-api/src/main/java/ao/creativemode/kixi/dto/term/TermResponse.java
+++ b/services/backend-api/src/main/java/ao/creativemode/kixi/dto/term/TermResponse.java
@@ -1,0 +1,12 @@
+package ao.creativemode.kixi.dto.term;
+
+import java.time.LocalDateTime;
+
+public record TermResponse(
+        Long id,
+        int number,
+        String name,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt,
+        LocalDateTime deletedAt
+) {}

--- a/services/backend-api/src/main/java/ao/creativemode/kixi/model/Term.java
+++ b/services/backend-api/src/main/java/ao/creativemode/kixi/model/Term.java
@@ -1,0 +1,41 @@
+package ao.creativemode.kixi.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+import java.time.LocalDateTime;
+
+@Table("terms")
+@Getter
+@Setter
+public class Term {
+
+    @Id
+    private Long id;
+
+    private int number;
+    private String name;
+
+    @CreatedDate
+    @Column("created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column("updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column("deleted_at")
+    private LocalDateTime deletedAt;
+
+    public void markAsDeleted() {
+        this.deletedAt = LocalDateTime.now();
+    }
+
+    public void restore() {
+        this.deletedAt = null;
+    }
+}

--- a/services/backend-api/src/main/java/ao/creativemode/kixi/repository/TermRepository.java
+++ b/services/backend-api/src/main/java/ao/creativemode/kixi/repository/TermRepository.java
@@ -1,0 +1,13 @@
+package ao.creativemode.kixi.repository;
+
+import ao.creativemode.kixi.model.Term;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+public interface TermRepository extends ReactiveCrudRepository<Term, Long> {
+    Flux<Term> findAllByDeletedAtIsNull();
+    Flux<Term> findAllByDeletedAtIsNotNull();
+    Mono<Term> findByIdAndDeletedAtIsNull(Long id);
+    Mono<Term> findByIdAndDeletedAtIsNotNull(Long id);
+}

--- a/services/backend-api/src/main/java/ao/creativemode/kixi/service/TermService.java
+++ b/services/backend-api/src/main/java/ao/creativemode/kixi/service/TermService.java
@@ -1,0 +1,83 @@
+package ao.creativemode.kixi.service;
+
+import ao.creativemode.kixi.common.exception.ApiException;
+import ao.creativemode.kixi.dto.term.TermRequest;
+import ao.creativemode.kixi.dto.term.TermResponse;
+import ao.creativemode.kixi.model.Term;
+import ao.creativemode.kixi.repository.TermRepository;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import java.time.LocalDateTime;
+
+@Service
+public class TermService {
+
+    private final TermRepository repository;
+
+    public TermService(TermRepository repository) {
+        this.repository = repository;
+    }
+
+    public Flux<TermResponse> findAllActive() {
+        return repository.findAllByDeletedAtIsNull().map(this::toResponse);
+    }
+
+    public Flux<TermResponse> findAllDeleted() {
+        return repository.findAllByDeletedAtIsNotNull().map(this::toResponse);
+    }
+
+    public Mono<TermResponse> findByIdActive(Long id) {
+        return repository.findByIdAndDeletedAtIsNull(id)
+                .switchIfEmpty(Mono.error(ApiException.notFound("Term not found")))
+                .map(this::toResponse);
+    }
+
+    public Mono<TermResponse> create(TermRequest dto) {
+        Term entity = new Term();
+        entity.setName(dto.name());
+        entity.setNumber(dto.number());
+        return repository.save(entity).map(this::toResponse);
+    }
+
+    public Mono<TermResponse> update(Long id, TermRequest dto) {
+        return repository.findByIdAndDeletedAtIsNull(id)
+                .switchIfEmpty(Mono.error(ApiException.notFound("Term not found")))
+                .flatMap(entity -> {
+                    entity.setName(dto.name());
+                    entity.setNumber(dto.number());
+                    entity.setUpdatedAt(LocalDateTime.now());
+                    return repository.save(entity);
+                })
+                .map(this::toResponse);
+    }
+
+    public Mono<Void> softDelete(Long id) {
+        return repository.findByIdAndDeletedAtIsNull(id)
+                .switchIfEmpty(Mono.error(ApiException.notFound("Term not found")))
+                .flatMap(entity -> {
+                    entity.markAsDeleted();
+                    return repository.save(entity);
+                }).then();
+    }
+
+    public Mono<Void> restore(Long id) {
+        return repository.findByIdAndDeletedAtIsNotNull(id)
+                .switchIfEmpty(Mono.error(ApiException.badRequest("Term is not in trash")))
+                .flatMap(entity -> {
+                    entity.restore();
+                    return repository.save(entity);
+                }).then();
+    }
+
+    public Mono<Void> hardDelete(Long id) {
+        return repository.findByIdAndDeletedAtIsNotNull(id)
+                .switchIfEmpty(Mono.error(ApiException.badRequest("Only trashed terms can be purged")))
+                .flatMap(repository::delete);
+    }
+
+    private TermResponse toResponse(Term entity) {
+        return new TermResponse(entity.getId(), entity.getNumber(), entity.getName(),
+                entity.getCreatedAt(), entity.getUpdatedAt(), entity.getDeletedAt());
+    }
+}

--- a/services/backend-api/src/main/resources/application.properties.exemple
+++ b/services/backend-api/src/main/resources/application.properties.exemple
@@ -1,3 +1,0 @@
-spring.r2dbc.url=r2dbc:postgresql://localhost:5432/seu_banco
-spring.r2dbc.username=postgres
-spring.r2dbc.password=sua_senha

--- a/services/backend-api/src/main/resources/db/migration/V1_create_term_table.sql
+++ b/services/backend-api/src/main/resources/db/migration/V1_create_term_table.sql
@@ -1,0 +1,15 @@
+-- Script de criação da tabela 'terms'
+CREATE TABLE IF NOT EXISTS terms (
+    id SERIAL PRIMARY KEY,
+    number INTEGER NOT NULL,
+    name VARCHAR(255) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP
+    );
+
+-- Índices para otimizar as buscas por Soft Delete
+CREATE INDEX idx_terms_deleted_at ON terms(deleted_at);
+
+-- Comentários para documentação da tabela
+COMMENT ON TABLE terms IS 'Tabela que armazena os períodos/trimestres letivos do sistema.';


### PR DESCRIPTION
This PR introduces the full CRUD lifecycle for the Term entity, built with Spring WebFlux and R2DBC for a fully reactive stack.

Key Changes
Database: Added Flyway migration (V1) with soft delete support and indexing.

Domain & Data: Implemented the Term model and reactive repository with built-in soft delete filtering.

Service Layer: Added business logic for CRUD operations, including trash/restore functionality.

API: Exposed RESTful endpoints at /api/v1/terms.

How to test
Verify the terms table creation via Flyway on startup.

POST /api/v1/terms (Create)

GET /api/v1/terms (List active)

DELETE /api/v1/terms/{id} (Soft delete)

POST /api/v1/terms/{id}/restore (Restore)

DELETE /api/v1/terms/{id}/purge (Permanent delete)

Checklist
[x] Local tests passed (APIDog)

[x] Flyway migration included

[x] Reactive patterns & Clean Code followed