### PR TITLE
refactor: enhance Term entity logic and database schema #16

### DIFF
--- a/services/backend-api/src/main/java/ao/creativemode/kixi/model/Term.java
+++ b/services/backend-api/src/main/java/ao/creativemode/kixi/model/Term.java
@@ -1,7 +1,6 @@
 package ao.creativemode.kixi.model;
 
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -12,6 +11,9 @@ import java.time.LocalDateTime;
 @Table("terms")
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Term {
 
     @Id
@@ -33,6 +35,10 @@ public class Term {
 
     public void markAsDeleted() {
         this.deletedAt = LocalDateTime.now();
+    }
+
+    public boolean isDeleted() {
+        return deletedAt != null;
     }
 
     public void restore() {

--- a/services/backend-api/src/main/resources/db/migration/V1_create_term_table.sql
+++ b/services/backend-api/src/main/resources/db/migration/V1_create_term_table.sql
@@ -1,11 +1,11 @@
 -- Script de criação da tabela 'terms'
 CREATE TABLE IF NOT EXISTS terms (
-    id SERIAL PRIMARY KEY,
+    id BIGSERIAL PRIMARY KEY,
     number INTEGER NOT NULL,
     name VARCHAR(255) NOT NULL,
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP,
-    deleted_at TIMESTAMP
+    created_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    updated_at  TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    deleted_at  TIMESTAMP WITH TIME ZONE DEFAULT NULL,
     );
 
 -- Índices para otimizar as buscas por Soft Delete


### PR DESCRIPTION
This PR refactors the initial Term entity implementation to improve code maintainability and database precision. It moves domain logic into the model and updates the schema for better scalability.

Improvements
Domain Model: Refactored Term.java to include helper methods (isDeleted) and applied Lombok constructor annotations .

Database Schema: Updated terms table to use BIGSERIAL and TIMESTAMPTZ.

Data Integrity: Added NOT NULL constraints and DEFAULT values to auditing columns (created_at, updated_at).